### PR TITLE
Remove duplicate: Vulkan Kompute

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4543,10 +4543,6 @@ projects:
     category: geospatial-data
     conda_id: conda-forge/prettymaps
     pypi_id: prettymaps
-  - name: kompute
-    github_id: KomputeProject/kompute
-    category: gpu-utilities
-    pypi_id: kp
   - name: deepsnap
     github_id: snap-stanford/deepsnap
     category: graph


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [x] Other, please describe: remove duplicate

**Description:**
This removes a duplicate instance of the `kompute` project. `Vulkan Kompute` is still present on [line 4164](https://github.com/ml-tooling/best-of-ml-python/blob/860fe5a0c5958fd4b7452cfb29d23f45bd042a4f/projects.yaml#L4164).

**Checklist:**
- [x] I have read the [CONTRIBUTING](https://github.com/ml-tooling/best-of-ml-python/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
