### PR TITLE
Add LangGraph project to ml-frameworks category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4668,3 +4668,7 @@ projects:
   - github_id: juspay/neurolink
     category: ml-frameworks
     description: Enterprise-grade LLM integration framework for building production-ready AI applications with built-in hallucination prevention, RAG, and MCP support
+    - name: LangGraph
+  - github_id: langchain-ai/langgraph
+    category: ml-frameworks
+    description: Framework for building stateful, multi-actor LLM applications and agents.


### PR DESCRIPTION
Adds LangGraph (langchain-ai/langgraph) to the ml-frameworks category.

LangGraph is a framework for building stateful, multi-actor LLM applications and agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add LangGraph (`langchain-ai/langgraph`) to the `ml-frameworks` category. Updates projects.yaml with the project name and description.

<sup>Written for commit 44dd29d83be26cb5cd948ad6c79b6b1eb6e80578. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

