### PR TITLE
Add CrewAI project to ml-frameworks category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4668,3 +4668,7 @@ projects:
   - github_id: juspay/neurolink
     category: ml-frameworks
     description: Enterprise-grade LLM integration framework for building production-ready AI applications with built-in hallucination prevention, RAG, and MCP support
+    - name: CrewAI
+  - github_id: crewAIInc/crewAI
+    category: ml-frameworks
+    description: Framework for orchestrating role-playing autonomous AI agents.


### PR DESCRIPTION
Adds CrewAI (crewAIInc/crewAI) to the ml-frameworks category.

CrewAI is a framework for orchestrating role-playing autonomous AI agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CrewAI (`crewAIInc/crewAI`) to the `ml-frameworks` category with a short description for better discovery. Updates `projects.yaml` to include a framework for orchestrating role-playing autonomous AI agents.

<sup>Written for commit 405f15e6c20f806f29c9a1fa91a143e0687ce32a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

