### PR TITLE
Add project: arsenal

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4668,3 +4668,7 @@ projects:
   - github_id: juspay/neurolink
     category: ml-frameworks
     description: Enterprise-grade LLM integration framework for building production-ready AI applications with built-in hallucination prevention, RAG, and MCP support
+  - name: arsenal
+    github_id: darshjme/arsenal
+    category: nlp
+    description: 100 zero-dependency Python libraries for LLM agent failure modes in production. Each library solves one specific failure class. 4375 tests. MIT license.


### PR DESCRIPTION
Arsenal is a collection of 100 focused, zero-dependency Python libraries for LLM agent failure modes in production. Each library solves one specific failure class. 4375 tests. MIT license. https://github.com/darshjme/arsenal

Added to projects.yaml under the `nlp` category as per CONTRIBUTING.md guidelines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `darshjme/arsenal` to projects.yaml under the nlp category to include a collection of 100 zero-dependency Python libraries for LLM agent failure modes. This makes the project discoverable in our catalog.

<sup>Written for commit 302922047c0524fc9ccf8491c0e02d39e2416a80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

