### PR TITLE
Add crdt-merge — 26 CRDT-compliant model merge strategies

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4671,6 +4671,6 @@ projects:
 - name: crdt-merge
   github_id: mgillr/crdt-merge
   pypi_id: crdt-merge
-  category: model-serialization
+  category: model-serialisation
   description: "26 CRDT-compliant model merge strategies (SLERP, TIES, DARE, Fisher, LoRA) with mathematical convergence guarantees"
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -4668,3 +4668,9 @@ projects:
   - github_id: juspay/neurolink
     category: ml-frameworks
     description: Enterprise-grade LLM integration framework for building production-ready AI applications with built-in hallucination prevention, RAG, and MCP support
+- name: crdt-merge
+  github_id: mgillr/crdt-merge
+  pypi_id: crdt-merge
+  category: model-serialization
+  description: "26 CRDT-compliant model merge strategies (SLERP, TIES, DARE, Fisher, LoRA) with mathematical convergence guarantees"
+


### PR DESCRIPTION
Hi! 👋

I'd like to add [crdt-merge](https://github.com/mgillr/crdt-merge) to the model-serialization or model tools category.

**crdt-merge** provides 26 model merge strategies (SLERP, TIES, DARE, Fisher, LoRA, evolutionary, and more) that are all provably CRDT-compliant via a novel two-layer OR-Set architecture.

Key ML features:
- All 26 strategies satisfy commutativity, associativity, and idempotency
- HuggingFace Hub native integration
- Federated learning aggregation without a parameter server
- Continual merge engine (NeurIPS 2025-inspired)
- mergekit compatibility layer
- GPU-accelerated

PyPI: `pip install crdt-merge[model]`

Thanks for maintaining this list! 🙏

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `crdt-merge` to the model-serialisation category in projects.yaml, including GitHub/PyPI metadata and a description for a library with 26 CRDT‑compliant model merge strategies (SLERP, TIES, DARE, Fisher, LoRA) with convergence guarantees.

<sup>Written for commit 12181e347e44efd6f515bd9796ab1e67abc07d3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

