### PR TITLE
Add project: Promptise Foundry

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4668,3 +4668,8 @@ projects:
   - github_id: juspay/neurolink
     category: ml-frameworks
     description: Enterprise-grade LLM integration framework for building production-ready AI applications with built-in hallucination prevention, RAG, and MCP support
+  - name: Promptise Foundry
+    github_id: promptise-com/foundry
+    pypi_id: promptise
+    category: nlp
+    description: Production Python framework for agentic AI and MCP servers with autonomous runtime, memory, tool integration, governance, guardrails, semantic caching, and observability.


### PR DESCRIPTION
Adding [Promptise Foundry](https://github.com/promptise-com/foundry) to `projects.yaml` under the `nlp` category.

Promptise Foundry is a production-grade Python framework for building agentic AI systems and MCP servers, covering autonomous runtime, memory, tool integration, governance (budget/health/mission/secrets), guardrails, semantic caching, and compliance-grade observability. It sits alongside other LLM/agent-oriented conversational AI tooling in the NLP category.

Compliance with CONTRIBUTING.md:
- Edit made to `projects.yaml` only (never README.md).
- Title format: `Add project: project-name`.
- GitHub ID: `promptise-com/foundry` (Apache-2.0, Python 3.10+, actively maintained, 812 stars — above the 300 `min_stars` threshold).
- PyPI ID: `promptise`.
- Category: `nlp` (conversational AI / agent tooling).
- One project per PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Promptise Foundry to `projects.yaml` under the `nlp` category. Includes `github_id: promptise-com/foundry` and `pypi_id: promptise`; adds a production Python framework for agentic systems and MCP servers to our catalog.

<sup>Written for commit f04b4a0127a76880de01b8c1e405a2263e0ee05b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

